### PR TITLE
feat: Update depth indicator and page immersion based on feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="depth-marker">0m</div>
+    <div id="depth-indicator-container" style="display: none;"><div id="depth-indicator-line"></div><div id="depth-indicator-text">0 METERS DEEP</div></div>
     <div id="scroll-container">
         <section id="surface" class="ocean-layer" data-depth="0" data-creatures="Seagulls, Pelicans" data-facts="The ocean surface is teeming with life.">
             <h2>Surface (Epipelagic Zone)</h2>

--- a/script.js
+++ b/script.js
@@ -1,29 +1,54 @@
 document.addEventListener('DOMContentLoaded', () => {
     const scrollContainer = document.getElementById('scroll-container');
-    const depthMarker = document.getElementById('depth-marker');
+    // const depthMarker = document.getElementById('depth-marker'); // Removed
+    const depthIndicatorContainer = document.getElementById('depth-indicator-container');
+    const depthIndicatorText = document.getElementById('depth-indicator-text');
     const oceanLayers = Array.from(document.querySelectorAll('.ocean-layer'));
     const body = document.body;
 
     // Max depth roughly based on Challenger Deep for gradient calculation
-    const MAX_DEPTH = 11034;
+    // const MAX_DEPTH = 11034; // Removed/Replaced
+    const MAX_DISPLAY_DEPTH = 10924; // For the text display
 
     // Initial colors for gradient (light to dark)
     const surfaceColor = [135, 206, 235]; // Sky Blue
     const deepColor = [0, 0, 51];      // Deep Dark Blue/Black
 
+    // SUNLIGHT_ZONE_ENTRY_SCROLL will be dynamic via offsetTop
+
     function updateDepth() {
         const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
         const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-        const currentDepth = Math.min(MAX_DEPTH, (scrollTop / scrollHeight) * MAX_DEPTH);
+        // const currentDepth = Math.min(MAX_DEPTH, (scrollTop / scrollHeight) * MAX_DEPTH); // Old calculation
+        // depthMarker.textContent = `${Math.round(currentDepth)}m`; // Old marker update
 
-        depthMarker.textContent = `${Math.round(currentDepth)}m`;
+        // Indicator Visibility & Depth Calculation
+        const sunlightZone = document.getElementById('sunlight-zone');
+        if (!sunlightZone) {
+            console.error("#sunlight-zone element not found!");
+            return;
+        }
+        const sunlightZoneOffsetTop = sunlightZone.offsetTop;
 
-        // Calculate color transition
-        const scrollFraction = Math.min(scrollTop / (scrollHeight * 0.8), 1); // Reach darkest color before hitting absolute bottom
+        if (scrollTop >= sunlightZoneOffsetTop) {
+            if (depthIndicatorContainer) depthIndicatorContainer.style.display = 'flex';
 
-        const r = Math.round(surfaceColor[0] + (deepColor[0] - surfaceColor[0]) * scrollFraction);
-        const g = Math.round(surfaceColor[1] + (deepColor[1] - surfaceColor[1]) * scrollFraction);
-        const b = Math.round(surfaceColor[2] + (deepColor[2] - surfaceColor[2]) * scrollFraction);
+            const scrollRangeForDepthDisplay = scrollHeight - sunlightZoneOffsetTop;
+            const currentScrollInDisplayRange = Math.max(0, scrollTop - sunlightZoneOffsetTop);
+            let displayedDepth = (currentScrollInDisplayRange / scrollRangeForDepthDisplay) * MAX_DISPLAY_DEPTH;
+            displayedDepth = Math.min(displayedDepth, MAX_DISPLAY_DEPTH); // Cap at max depth
+            if (depthIndicatorText) depthIndicatorText.textContent = Math.round(displayedDepth) + " METERS DEEP";
+
+        } else {
+            if (depthIndicatorContainer) depthIndicatorContainer.style.display = 'none';
+        }
+
+        // Calculate color transition using global scroll fraction
+        const globalScrollFraction = Math.min(scrollTop / (scrollHeight * 0.95), 1); // Reach darkest color a bit before absolute bottom
+
+        const r = Math.round(surfaceColor[0] + (deepColor[0] - surfaceColor[0]) * globalScrollFraction);
+        const g = Math.round(surfaceColor[1] + (deepColor[1] - surfaceColor[1]) * globalScrollFraction);
+        const b = Math.round(surfaceColor[2] + (deepColor[2] - surfaceColor[2]) * globalScrollFraction);
 
         body.style.backgroundColor = `rgb(${r}, ${g}, ${b})`;
 

--- a/style.css
+++ b/style.css
@@ -4,6 +4,7 @@ body {
     color: #fff;
     background-color: #000033; /* Deepest ocean color */
     overflow-x: hidden; /* Prevent horizontal scroll */
+    min-height: 8000vh; /* Extremely tall for immersive scrolling */
 }
 
 #scroll-container {
@@ -65,6 +66,7 @@ body {
     border-radius: 5px;
     font-size: 1.5em;
     z-index: 1000;
+    display: none !important; /* Hide old depth marker */
 }
 
 #ocean-background {
@@ -108,5 +110,53 @@ body {
     #depth-marker {
         font-size: 1em;
         padding: 6px 10px;
+    }
+}
+
+/* Make page extremely tall */
+/* body rule updated above */
+
+#depth-indicator-container {
+    position: fixed;
+    bottom: 20vh; /* Fixed at 20% from the bottom of the viewport */
+    left: 0;
+    width: 100%;
+    display: flex; /* Changed to flex for easier alignment if needed */
+    flex-direction: column;
+    align-items: center;
+    z-index: 1000;
+    pointer-events: none; /* Allow clicks to pass through */
+}
+
+#depth-indicator-line {
+    width: 80%; /* Dashed line doesn't have to be full width, can be adjusted */
+    border-top: 2px dashed #fff;
+    margin-bottom: 10px; /* Space between line and text */
+}
+
+#depth-indicator-text {
+    color: #fff;
+    font-size: 1.8em; /* Prominent text */
+    font-weight: bold;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.7); /* Text shadow for better readability */
+}
+
+/* Adjustments for new depth marker visibility (JS will toggle display:none on container) */
+/* Hide old depth marker if it was missed or for safety */
+/* #depth-marker rule updated above */
+
+/* Responsive adjustments for new depth indicator */
+@media (max-width: 768px) {
+    #depth-indicator-text {
+        font-size: 1.5em;
+    }
+    #depth-indicator-line {
+        width: 90%;
+    }
+}
+
+@media (max-width: 480px) {
+    #depth-indicator-text {
+        font-size: 1.2em;
     }
 }


### PR DESCRIPTION
This commit incorporates your feedback to enhance the deep-sea diving experience:

- Replaced the previous top-right depth marker with a new full-width depth indicator.
- The new indicator consists of a white dashed line and a numeric depth text (e.g., "436 METERS DEEP").
- This indicator is fixed at 20% from the bottom of the viewport.
- It only becomes visible when you scroll into the "Sunlight Zone" and hides if scrolled back to the surface.
- The numeric depth updates in real-time, starting from the equivalent of 0 meters at the Sunlight Zone entry and reaching a maximum of 10924 meters at the page bottom.
- The overall page height (`min-height` in CSS) has been significantly increased (to `8000vh`) to provide a more gradual and immersive scrolling experience.
- JavaScript logic in `script.js` has been updated to manage the visibility, positioning, and dynamic text of the new depth indicator.
- CSS in `style.css` has been updated for the new indicator's styling and the increased body height.
- HTML in `index.html` was updated to include the new elements for the depth indicator.