### PR TITLE
feat: Add surface wave animation and adjust particle background

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <canvas id="wave-canvas"></canvas>
     <div id="depth-indicator-container" style="display: none;"><div id="depth-indicator-line"></div><div id="depth-indicator-text">0 METERS DEEP</div></div>
     <div id="scroll-container">
         <section id="surface" class="ocean-layer" data-depth="0" data-creatures="Seagulls, Pelicans" data-facts="The ocean surface is teeming with life.">
@@ -67,6 +68,7 @@
     </div>
     <canvas id="ocean-background"></canvas>
     <script src="background.js"></script>
+    <script src="waves.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -71,10 +71,10 @@ body {
 
 #ocean-background {
     position: fixed;
-    top: 0;
+    top: 15vh; /* Match the height of #wave-canvas */
     left: 0;
     width: 100%;
-    height: 100%;
+    height: calc(100% - 15vh); /* Fill remaining viewport height */
     z-index: -1; /* Behind all content */
 }
 
@@ -159,4 +159,14 @@ body {
     #depth-indicator-text {
         font-size: 1.2em;
     }
+}
+
+#wave-canvas {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 15vh; /* Waves occupy top 15% of viewport height */
+    z-index: 10; /* Above main background, below depth indicator if they could overlap */
+    /* background-color: #87CEEB; */ /* Optional: for testing, or if JS doesn't fill it */
 }

--- a/waves.js
+++ b/waves.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const canvas = document.getElementById('wave-canvas');
+    if (!canvas) {
+        console.error('Wave canvas element not found!');
+        return;
+    }
+    const ctx = canvas.getContext('2d');
+
+    let waveFrequency = 0.02;
+    let waveAmplitude = 20;
+    let waveSpeed = 0.02;
+    let phase = 0;
+
+    // Colors
+    const waveColor1 = 'rgba(173, 216, 230, 0.7)'; // Light blue with some transparency
+    const waveColor2 = 'rgba(135, 206, 250, 0.5)'; // Slightly different light blue
+    const waveColor3 = 'rgba(240, 248, 255, 0.3)'; // Almost white (AliceBlue) foam tips
+
+    function resizeCanvas() {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight * 0.15; // Match CSS vh, or fixed like 100px
+        waveAmplitude = canvas.height / 3; // Adjust amplitude based on canvas height
+    }
+
+    function drawWave(color, amplitude, frequency, currentPhase, yOffset) {
+        ctx.beginPath();
+        ctx.moveTo(0, canvas.height); // Start from bottom left of canvas
+
+        for (let x = 0; x < canvas.width; x++) {
+            // Primary wave
+            const yBase = canvas.height / 1.5 + yOffset; // Base Y position for this wave
+            const y = yBase + Math.sin(x * frequency + currentPhase) * amplitude;
+            ctx.lineTo(x, y);
+        }
+        ctx.lineTo(canvas.width, canvas.height); // Go to bottom right
+        ctx.lineTo(0, canvas.height); // Go to bottom left to close path
+        ctx.fillStyle = color;
+        ctx.fill();
+    }
+
+    function animate() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+        phase += waveSpeed;
+
+        // Draw multiple waves for a more appealing effect
+        // Base wave (darker)
+        drawWave(waveColor1, waveAmplitude, waveFrequency, phase, 0);
+        // Middle wave (slightly lighter, different phase/frequency for variation)
+        drawWave(waveColor2, waveAmplitude * 0.7, waveFrequency * 1.2 + 0.01, phase * 0.8, 5);
+        // Top wave / foam (lighter, smaller amplitude)
+        drawWave(waveColor3, waveAmplitude * 0.4, waveFrequency * 1.5 + 0.02, phase * 1.2, 10);
+
+
+        requestAnimationFrame(animate);
+    }
+
+    window.addEventListener('resize', resizeCanvas);
+
+    // Initial setup
+    resizeCanvas();
+    animate();
+});


### PR DESCRIPTION
This commit introduces an animated wave effect at the top of the page (water surface) and ensures the existing particle animation is displayed correctly below it.

- Added a new `<canvas id="wave-canvas">` to `index.html`.
- Styled `#wave-canvas` in `style.css` to be fixed at the top (15vh height) for the wave animation.
- Created `waves.js` which uses the Canvas API and `requestAnimationFrame` to draw and animate multiple sine waves, simulating a gentle water surface.
- Linked `waves.js` in `index.html`.
- Modified the CSS for `#ocean-background` (particle animation canvas) in `style.css`. Its `top` is now `15vh` and `height` is `calc(100% - 15vh)` so that particles appear to originate from below the wave animation.

The previously implemented blue-to-black background color transition based on depth remains active.